### PR TITLE
Updated metrics.md with new naming conventions

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,7 +19,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_requests_total` (Counter) - Count of front end requests handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -27,7 +27,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_requests_duration_seconds` (Histogram) - Histogram of front end request durations handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -35,7 +35,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_written_byte_total` (Counter) - Count of bytes written in front end requests handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -43,7 +43,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_proxy_requests_total` (Counter) - The total number of requests Trickster has handled.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `http_status` - The HTTP response code provided by the origin
@@ -52,14 +52,14 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_proxy_points_total` (Counter) - The total number of data points Trickster has handled.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `path` - the Path portion of the requested URL
 
 * `trickster_proxy_request_duration_seconds` (Histogram) - Time required to proxy a given Prometheus query.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `http_status` - The HTTP response code provided by the origin
@@ -80,14 +80,14 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_cache_operation_objects_total` (Counter) - The total number of objects upon which the Trickster cache has operated.
   * labels:
     * `cache_name` - the name of the configured cache performing the operation$
-    * `cache_type` - the type of the configured cache performing the operation
+    * `provider` - the type of the configured cache performing the operation
     * `operation` - the name of the operation being performed (read, write, etc.)
     * `status` - the result of the operation being performed
 
 * `trickster_cache_operation_bytes_total` (Counter) - The total number of bytes upon which the Trickster cache has operated.
   * labels:
     * `cache_name` - the name of the configured cache performing the operation$
-    * `cache_type` - the type of the configured cache performing the operation
+    * `provider` - the type of the configured cache performing the operation
     * `operation` - the name of the operation being performed (read, write, etc.)
     * `status` - the result of the operation being performed
 
@@ -98,29 +98,29 @@ The following metrics are available only for Caches Types whose object lifecycle
 * `trickster_cache_events_total` (Counter) - The total number of events that change the Trickster cache, such as retention policy evictions.
   * labels:
     * `cache_name` - the name of the configured cache experiencing the event$
-    * `cache_type` - the type of the configured cache experiencing the event
+    * `provider` - the type of the configured cache experiencing the event
     * `event` - the name of the event being performed
     * `reason` - the reason the event occurred
 
 * `trickster_cache_usage_objects` (Gauge) - The current count of objects in the Trickster cache.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache$
+    * `provider` - the type of the configured cache$
 
 * `trickster_cache_usage_bytes` (Gauge) - The current count of bytes in the Trickster cache.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache$
+    * `provider` - the type of the configured cache$
 
 * `trickster_cache_max_usage_objects` (Gauge) - The maximum allowed size of the Trickster cache in objects.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache
+    * `provider` - the type of the configured cache
 
 * `trickster_cache_max_usage_bytes` (Gauge) - The maximum allowed size of the Trickster cache in bytes.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache
+    * `provider` - the type of the configured cache
 
 ---
 


### PR DESCRIPTION
changed occurences of "origin_type" and "cache_type" to "provider"
Based on issue #495